### PR TITLE
Added missing header in GGPack.h

### DIFF
--- a/include/GGPack.h
+++ b/include/GGPack.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstring>
 #include <string>
 #include <map>
 #include <vector>
@@ -6,6 +7,7 @@
 #include <iostream>
 #include <sstream>
 #include <map>
+
 
 namespace ng
 {


### PR DESCRIPTION
This small change allow to compile engge in ArchLinux.