### PR TITLE
Upgrade TravisCI to Ubuntu 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: xenial
+dist: bionic
 matrix:
   include:
   - name: Linux


### PR DESCRIPTION
Linux user are more likely to use Ubuntu 18.04 and the precompiled binaries are going to be easier to run.